### PR TITLE
Optional kill button

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A big thanks to [Craig Kerstiens](http://www.craigkerstiens.com/2013/01/10/more-
 
 ## History
 
-View the [changelog](https://github.com/ankane/pghero/blob/master/CHANGELOG.md)
+View the [changelog](https://github.com/enova/pghero/blob/master/CHANGELOG.md)
 
 ## Contributing
 

--- a/app/views/pg_hero/home/_live_queries_table.html.erb
+++ b/app/views/pg_hero/home/_live_queries_table.html.erb
@@ -33,7 +33,9 @@
           <% unless @database.filter_data %>
             <%= button_to "Explain", explain_path, params: {query: query[:query]}, form: {target: "_blank"}, class: "btn btn-info" %>
           <% end %>
-          <%= button_to "Kill", kill_path(pid: query[:pid]), class: "btn btn-danger" %>
+          <% if PgHero.config["show_kill"] %>
+            <%= button_to "Kill", kill_path(pid: query[:pid]), class: "btn btn-danger" %>
+          <% end %>
         </td>
       </tr>
       <tr>

--- a/app/views/pg_hero/home/explain.html.erb
+++ b/app/views/pg_hero/home/explain.html.erb
@@ -5,8 +5,10 @@
     <div class="field"><%= text_area_tag :query, @query, placeholder: "Enter a SQL query" %></div>
     <p>
       <%= submit_tag "Explain", class: "btn btn-info", style: "margin-right: 10px;" %>
-      <%= submit_tag "Analyze", class: "btn btn-danger", style: "margin-right: 10px;" %>
-      <%= submit_tag "Visualize", class: "btn btn-danger" %>
+      <% if PgHero.config["show_analyze_and_visualize"] %>
+        <%= submit_tag "Analyze", class: "btn btn-danger", style: "margin-right: 10px;" %>
+        <%= submit_tag "Visualize", class: "btn btn-danger" %>
+      <% end %>
     </p>
   <% end %>
 

--- a/app/views/pg_hero/home/index.html.erb
+++ b/app/views/pg_hero/home/index.html.erb
@@ -188,7 +188,9 @@
 
 <% if @long_running_queries.any? %>
   <div class="content">
-    <%= button_to "Kill All", kill_long_running_queries_path, class: "btn btn-danger", style: "float: right;" %>
+    <% if PgHero.config["show_kill"] %>
+      <%= button_to "Kill All", kill_long_running_queries_path, class: "btn btn-danger", style: "float: right;" %>
+    <% end %>
     <h1>Long Running Queries</h1>
 
     <p>We recommend setting a statement timeout on all non-superusers with:</p>

--- a/app/views/pg_hero/home/live_queries.html.erb
+++ b/app/views/pg_hero/home/live_queries.html.erb
@@ -5,7 +5,9 @@
 
   <%= render partial: "live_queries_table", locals: {queries: @running_queries, vacuum_progress: @vacuum_progress} %>
 
-  <p><%= button_to "Kill all connections", kill_all_path, class: "btn btn-danger" %></p>
+  <% if PgHero.config["show_kill_all_connections"] %>
+    <p><% button_to "Kill all connections", kill_all_path, class: "btn btn-danger" %></p>
+  <% end %>
 
   <p class="text-muted">You may need to restart your app servers afterwards.</p>
 </div>

--- a/lib/generators/pghero/templates/config.yml.tt
+++ b/lib/generators/pghero/templates/config.yml.tt
@@ -44,3 +44,12 @@ databases:
 
 # Filter data from queries (experimental)
 # filter_data: true
+
+# Show Kill All Connections button on Live Queries tab
+# show_kill_all_connections: true
+
+# On Explain tab, Show Analyze and Visualize options
+# show_analyze_and_visualize: true
+
+# On Home Page , Live Queries Page , Show Kill button option
+# show_kill: true


### PR DESCRIPTION
Add customizations to the UI 

- Remove the Kill button for all the pages 
- Remove Visualize and Analyze from Explain page 
- Remove Kill All Connections from live queries page.